### PR TITLE
Add a function for recovering from network errors

### DIFF
--- a/ContentPass.podspec
+++ b/ContentPass.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "ContentPass"
-  spec.version      = "1.0.0"
+  spec.version      = "1.1.0"
   spec.summary      = "Handles all authentication and validation with contentpass servers for you."
 
   spec.homepage     = "https://contentpass.de"

--- a/ContentPassExample/ContentPassExample/ViewController.swift
+++ b/ContentPassExample/ContentPassExample/ViewController.swift
@@ -6,6 +6,7 @@ class ViewController: UIViewController {
     private let subscriptionLabel = UILabel()
     private let loginButton = UIButton(type: .system)
     private let logoutButton = UIButton(type: .system)
+    private let recoverButton = UIButton(type: .system)
 
     private var cancelBag = Set<AnyCancellable>()
 
@@ -37,12 +38,11 @@ class ViewController: UIViewController {
         view.backgroundColor = .white
         loginButton.setTitle("Login", for: .normal)
         logoutButton.setTitle("Logout", for: .normal)
+        recoverButton.setTitle("Recover from error", for: .normal)
     }
 
     private func setupLayout() {
-        let buttonStack = UIStackView(arrangedSubviews: [loginButton, logoutButton])
-        buttonStack.axis = .horizontal
-        let stack = UIStackView(arrangedSubviews: [authenticatedLabel, subscriptionLabel, buttonStack])
+        let stack = UIStackView(arrangedSubviews: [authenticatedLabel, subscriptionLabel, loginButton, logoutButton, recoverButton])
         stack.axis = .vertical
         stack.translatesAutoresizingMaskIntoConstraints = false
 
@@ -56,6 +56,7 @@ class ViewController: UIViewController {
     private func setupBindings() {
         loginButton.addTarget(self, action: #selector(onLoginClicked), for: .touchUpInside)
         logoutButton.addTarget(self, action: #selector(onLogoutClicked), for: .touchUpInside)
+        recoverButton.addTarget(self, action: #selector(onRecoverClicked), for: .touchUpInside)
 
         viewModel.$isAuthenticated
             .receive(on: DispatchQueue.main)
@@ -73,6 +74,12 @@ class ViewController: UIViewController {
             .map { "Has valid subscription: \($0)" }
             .assign(to: \.text, on: subscriptionLabel)
             .store(in: &cancelBag)
+
+        viewModel.$isError
+            .receive(on: DispatchQueue.main)
+            .map(!)
+            .assign(to: \.isHidden, on: recoverButton)
+            .store(in: &cancelBag)
     }
 
     @objc
@@ -83,5 +90,10 @@ class ViewController: UIViewController {
     @objc
     private func onLogoutClicked() {
         viewModel.logout()
+    }
+
+    @objc
+    private func onRecoverClicked() {
+        viewModel.recoverFromError()
     }
 }

--- a/ContentPassExample/ContentPassExample/ViewModel.swift
+++ b/ContentPassExample/ContentPassExample/ViewModel.swift
@@ -7,6 +7,7 @@ class ViewModel {
 
     @Published var isAuthenticated = false
     @Published var hasValidSubscription = false
+    @Published var isError = false
 
     init(contentPass: ContentPass) {
         defer {
@@ -43,6 +44,10 @@ class ViewModel {
     func logout() {
         contentPass.logout()
     }
+
+    func recoverFromError() {
+        contentPass.recoverFromError()
+    }
 }
 
 extension ViewModel: ContentPassDelegate {
@@ -51,13 +56,16 @@ extension ViewModel: ContentPassDelegate {
         case .initializing, .unauthenticated:
             isAuthenticated = false
             hasValidSubscription = false
+            isError = false
         case .error(let error):
             print(error)
             isAuthenticated = false
             hasValidSubscription = false
+            isError = true
         case .authenticated(let sub):
             isAuthenticated = true
             hasValidSubscription = sub
+            isError = false
         }
     }
 }

--- a/ContentPassExample/ContentPassExampleTests/Mocks/MockedAuthState.swift
+++ b/ContentPassExample/ContentPassExampleTests/Mocks/MockedAuthState.swift
@@ -18,7 +18,7 @@ class MockedAuthState: NSObject, OIDAuthStateWrapping {
     weak var stateChangeDelegate: OIDAuthStateChangeDelegate?
     var wasTokenRefreshPerformed = false
 
-    func performTokenRefresh() {
+    func performTokenRefresh(errorHandler: @escaping (Error) -> Void) {
         wasTokenRefreshPerformed = true
     }
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,17 @@ We have our own `ContentPassError` enum for the following cases:
 We also bubble up underlying errors that may occur because of connectivity problems or other issues regarding the OAuth flow.
 With these errors it's best practice to cast them to `NSError` and look up the error's `domain` and `code` on your favorite search engine.
 
+### Recovering from network errors
+
+Sometimes we encounter an error state while refreshing the tokens in the background due to bad or no internet connection.
+Since we don't monitor the device's connection state you need to tell the SDK that the network connection has been reestablished / improved. We will then refresh and revalidate the user's authentication tokens.
+
+```swift
+contentPass.recoverFromError()
+```
+
+
+
 ## License
 
 [MIT licensed](https://github.com/contentpass/contentpass-ios/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ or
 * Add the following `dependency` to your `Package.swift`:
 ```swift
 dependencies: [
-    .package(url: "https://github.com/contentpass/contentpass-ios", .upToNextMajor(from: "1.0.0"))
+    .package(url: "https://github.com/contentpass/contentpass-ios", .upToNextMajor(from: "1.1.0"))
 ]
 ```
 
@@ -38,7 +38,7 @@ In both cases don't forget to add the sdk to your targets.
 
 With [CocoaPods](https://guides.cocoapods.org/using/getting-started.html), add the following line to your `Podfile`:
 ```ruby
-  pod 'ContentPass', '~> 1.0.0'
+  pod 'ContentPass', '~> 1.1.0'
 ```
 
 Then, run `pod install` via terminal.

--- a/Sources/ContentPass/ContentPass.swift
+++ b/Sources/ContentPass/ContentPass.swift
@@ -123,6 +123,15 @@ public class ContentPass: NSObject {
         oidAuthState = nil
     }
 
+    /// Triggers validation of the authentication tokens.
+    ///
+    /// You might encounter error states because there was no or bad internet connection while refreshing the tokens.
+    /// Call this function to tell the `ContentPass` object that the internet connection recovered.
+    /// It then refreshes and / or reauthenticates the tokens if necessary.
+    public func recoverFromError() {
+        validateAuthState()
+    }
+
     // MARK: INTERNAL FUNCTIONS
 
     convenience init(configuration: Configuration, keychain: KeychainStoring) {
@@ -211,7 +220,10 @@ public class ContentPass: NSObject {
             state = .unauthenticated
             return
         }
-        authState.performTokenRefresh()
+
+        authState.performTokenRefresh { [weak self] error in
+            self?.state = .error(error)
+        }
     }
 
     private func didSetState(_ state: State) {

--- a/Sources/ContentPass/OIDAuthState+Wrapped.swift
+++ b/Sources/ContentPass/OIDAuthState+Wrapped.swift
@@ -1,13 +1,16 @@
 import AppAuth
 
 extension OIDAuthState: OIDAuthStateWrapping {
-    func performTokenRefresh() {
+    func performTokenRefresh(errorHandler: @escaping (Error) -> Void) {
         assert(errorDelegate != nil)
         assert(stateChangeDelegate != nil)
 
         setNeedsTokenRefresh()
-        // no completion handling needed because we implement the delegates
-        performAction(freshTokens: { _, _, _ in })
+
+        performAction { _, _, error in
+            guard let error = error else { return }
+            errorHandler(error)
+        }
     }
 
     var tokenScope: String? {

--- a/Sources/ContentPass/OIDAuthStateWrapping.swift
+++ b/Sources/ContentPass/OIDAuthStateWrapping.swift
@@ -15,5 +15,5 @@ protocol OIDAuthStateWrapping: NSSecureCoding {
     var errorDelegate: OIDAuthStateErrorDelegate? { get set }
     var stateChangeDelegate: OIDAuthStateChangeDelegate? { get set }
 
-    func performTokenRefresh()
+    func performTokenRefresh(errorHandler: @escaping (Error) -> Void)
 }


### PR DESCRIPTION
This enables publishers to "restart" the sdk in case it encountered a network error during token refresh.

Without this, they'd have needed to drop and reinitialize the sdk in case of those errors.

I don't very much like the current name `recoverFromError()` but I couldn't really come up with anything that I liked. See slack.